### PR TITLE
when creating an occupation it now shows the calendar widget. fixes #13

### DIFF
--- a/src/main/webapp/WEB-INF/occupations/calendar.jsp
+++ b/src/main/webapp/WEB-INF/occupations/calendar.jsp
@@ -643,7 +643,11 @@
 	text-align: center;
 }
 </style>
-
+<style>
+.xdsoft_datetimepicker {
+	z-index:20000 !important;
+}
+</style>
 
 <body>
 	<span>


### PR DESCRIPTION
the widget was already being called however, it was not being shown because the modal div was covering it.
