### PR TITLE
Enhanced the way shared occupations are displayed SPC-43 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/spaces/domain/occupation/SharedOccupation.java
+++ b/src/main/java/org/fenixedu/spaces/domain/occupation/SharedOccupation.java
@@ -121,6 +121,17 @@ public class SharedOccupation extends SharedOccupation_Base {
     }
 
     @Override
+    public String getSubject() {
+        if (super.getSubject() != null && !super.getSubject().isEmpty()) {
+            return super.getSubject();
+        }
+        if (getUser() != null) {
+            return getUser().getProfile().getDisplayName();
+        }
+        return super.getSubject();
+    }
+
+    @Override
     public void delete() {
         if (getRequest() != null) {
             setRequest(null);

--- a/src/main/java/org/fenixedu/spaces/ui/services/OccupationService.java
+++ b/src/main/java/org/fenixedu/spaces/ui/services/OccupationService.java
@@ -34,6 +34,7 @@ import org.fenixedu.spaces.core.service.NotificationService;
 import org.fenixedu.spaces.domain.Space;
 import org.fenixedu.spaces.domain.SpaceDomainException;
 import org.fenixedu.spaces.domain.occupation.Occupation;
+import org.fenixedu.spaces.domain.occupation.SharedOccupation;
 import org.fenixedu.spaces.domain.occupation.config.ExplicitConfigWithSettings;
 import org.fenixedu.spaces.domain.occupation.config.ExplicitConfigWithSettings.Frequency;
 import org.fenixedu.spaces.domain.occupation.config.ExplicitConfigWithSettings.MonthlyType;
@@ -405,7 +406,7 @@ public class OccupationService {
                     if (url != null && !url.isEmpty()) {
                         event.addProperty("url", url);
                     }
-                    event.addProperty("allDay", false);
+                    event.addProperty("allDay", occupation.getClass().equals(SharedOccupation.class));
                     event.addProperty("backgroundColor", colors[id % colors.length]);
                     event.addProperty("info", occupation.getInfo());
                     events.add(event);

--- a/src/main/webapp/WEB-INF/spaces-view/schedule.jsp
+++ b/src/main/webapp/WEB-INF/spaces-view/schedule.jsp
@@ -66,7 +66,7 @@
 			minTime : "08:00",
 			maxTime : "24:00",
 			axisFormat: 'H:mm',
-			allDaySlot : false,
+			allDaySlot : true,
 			defaultView: "agendaWeek",
 			firstDay: 1,
 			editable: false,


### PR DESCRIPTION
They are now considered all-day events and are shown in a different
section, thus, not polluting the rest of the schedule view.